### PR TITLE
updated addCorsMappings method

### DIFF
--- a/src/main/java/com/programming/techie/springredditclone/config/WebConfig.java
+++ b/src/main/java/com/programming/techie/springredditclone/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
         corsRegistry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOriginPatterns("*")
                 .allowedMethods("*")
                 .maxAge(3600L)
                 .allowedHeaders("*")


### PR DESCRIPTION
This method throws an exception at runtime. 
Exception: 
`java.lang.IllegalArgumentException: When allowCredentials is true, allowedOrigins cannot contain the special value "*" since that cannot be set on the "Access-Control-Allow-Origin" response header. To allow credentials to a set of origins, list them explicitly or consider using "allowedOriginPatterns" instead.`