### PR TITLE
#Lombok version in your project differently from the Spring Boot BOM …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok-mapstruct-binding</artifactId>
-                            <version>0.2.0</version>
+                            <version>1.8.26</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
This implies that the minimal Spring Boot version is 3.1.4, unless you want to meddle with the Spring Boot autoconfiguration and set the Lombok version in your project differently from the Spring Boot [BOM](https://www.baeldung.com/spring-maven-bom) defined in spring-boot-dependencies.…defined